### PR TITLE
feat: add host func handler (WIP)

### DIFF
--- a/src/include/components/browser/browser_handler.h
+++ b/src/include/components/browser/browser_handler.h
@@ -3,6 +3,7 @@
 
 #include <include/cef_client.h>
 #include <include/cef_version.h>
+#include <include/wrapper/cef_message_router.h>
 
 enum CursorType: unsigned char {
     CursorDefault = 0,
@@ -16,6 +17,7 @@ private:
     int textureId;
     unsigned short windowWidth;
     unsigned short windowHeight;
+    CefRefPtr<CefMessageRouterBrowserSide> message_router_;
     
 public:
     BrowserHandler(int textureId, unsigned short width, unsigned short height);
@@ -55,6 +57,10 @@ public:
     void OnDocumentAvailableInMainFrame(CefRefPtr<CefBrowser> browser) override;
     void OnBeforeDownload(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDownloadItem> download_item, const CefString &suggested_name, CefRefPtr<CefBeforeDownloadCallback> callback) override;
     void OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDownloadItem> download_item, CefRefPtr<CefDownloadItemCallback> callback) override;
+    bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+                                                  CefRefPtr<CefFrame> frame,
+                                                  CefProcessId source_process,
+                                                  CefRefPtr<CefProcessMessage> message) override;
 };
 
 #endif

--- a/src/include/components/browser/host_func_handler.cpp
+++ b/src/include/components/browser/host_func_handler.cpp
@@ -1,0 +1,43 @@
+#include "host_func_handler.h"
+#include "browser_handler.h"
+#include <include/cef_base.h>
+#include <include/base/cef_callback.h>
+#include <include/cef_app.h>
+#include <include/cef_parser.h>
+#include <include/views/cef_browser_view.h>
+#include <include/views/cef_window.h>
+#include <include/wrapper/cef_closure_task.h>
+#include <include/wrapper/cef_helpers.h>
+#include <sstream>
+#include <string>
+#include <cmath>
+#include <XPLMProcessing.h>
+#include <XPLMUtilities.h>
+#include <XPLMGraphics.h>
+#include "config.h"
+#include "appstate.h"
+#include "path.h"
+
+
+bool HostFunctionHandler::OnQuery(CefRefPtr<CefBrowser> browser,
+                             CefRefPtr<CefFrame> frame,
+                             int64_t query_id,
+                             const CefString& request,
+                             bool persistent,
+                             CefRefPtr<Callback> callback) {
+    // The `request` string is whatever you pass from JS
+    if (request == "myHostFunction") {
+        // Do something in C++
+        // e.g., read a file, compute a value, call some API, etc.
+
+        // Return data back to JS
+        callback->Success("Hello from C++ host!");
+        
+        // We handled this query
+        return true;
+    }
+    
+    // If we do not recognize this request string,
+    // return false so other handlers (if any) can process it
+    return false;
+}

--- a/src/include/components/browser/host_func_handler.h
+++ b/src/include/components/browser/host_func_handler.h
@@ -1,0 +1,15 @@
+#include <include/wrapper/cef_message_router.h>
+
+class HostFunctionHandler : public CefMessageRouterBrowserSide::Handler {
+public:
+    HostFunctionHandler() {}
+
+    // Called when JS calls window.cefQuery({request: 'something', ...})
+    virtual bool OnQuery(CefRefPtr<CefBrowser> browser,
+                         CefRefPtr<CefFrame> frame,
+                         int64_t query_id,
+                         const CefString& request,
+                         bool persistent,
+                         CefRefPtr<Callback> callback) override ;
+   
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,7 @@ PLUGIN_API int XPluginStart(char * name, char * sig, char * desc)
 {
     strcpy(name, FRIENDLY_NAME);
     strcpy(sig, BUNDLE_ID);
-    strcpy(desc, "Browser extension for the Avitab");
+    strcpy(desc, "Browser extension for the Avitab - Electron-fy-poc");
     XPLMEnableFeature("XPLM_USE_NATIVE_PATHS", 1);
     XPLMEnableFeature("XPLM_USE_NATIVE_WIDGET_WINDOWS", 1);
     


### PR DESCRIPTION
this should allow js func:
```
function callHostFunction() {
  window.cefQuery({
    request: 'myHostFunction',
    onSuccess: function (response) {
      console.log('Success from host:', response);
    },
    onFailure: function (error_code, error_message) {
      console.error('Failure from host:', error_code, error_message);
    },
  });
}
```
in browser

NOTE: WIP and will rebase